### PR TITLE
Use Entra L2 header

### DIFF
--- a/msal-dotnet-articles/docfx.json
+++ b/msal-dotnet-articles/docfx.json
@@ -42,6 +42,7 @@
     "globalMetadata": {
       "breadcrumb_path": "/entra/msal/dotnet/breadcrumb/toc.json",
       "extendBreadcrumb": true,
+      "uhfHeaderId": "MSDocsHeader-Entra",
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/microsoft-authentication-library-dotnet",
       "feedback_product_url": "https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues",


### PR DESCRIPTION
Because this content is using the /entra base URL, it needs to use the Entra L2 header. Thanks!