### PR TITLE
Fix typos in XML docs for TokenValidationParameters

### DIFF
--- a/dotnet/xml/Microsoft.IdentityModel.Tokens/TokenValidationParameters.xml
+++ b/dotnet/xml/Microsoft.IdentityModel.Tokens/TokenValidationParameters.xml
@@ -1766,7 +1766,7 @@
             Gets or sets a boolean to control if the audience will be validated during token validation.
             </summary>
         <value>To be added.</value>
-        <remarks>Validation of the audience, mitigates forwarding attacks. For example, a site that receives a token, could not replay it to another side.
+        <remarks>Validation of the audience mitigates forwarding attacks. For example, a site that receives a token could not replay it to another site.
             A forwarded token would contain the audience of the original site.
             This boolean only applies to default audience validation. If <see cref="P:Microsoft.IdentityModel.Tokens.TokenValidationParameters.AudienceValidator" /> is set, it will be called regardless of whether this
             property is true or false.


### PR DESCRIPTION
1) Remove comma in first sentence of remarks of `TokenValidationParameters.ValidateAudience` to match first sentence in remarks of `TokenValidationParameters.ValidateIssuer`.
2) Remove misplaced comma in second sentence of remarks of `TokenValidationParameters.ValidateAudience`
3) Fix typo from 'side' to 'site.'