### PR TITLE
[BULK] - DocuTune - Rebranding of Azure Active Directory to Microsoft Entra terminology (part 2)

### DIFF
--- a/msal-dotnet-articles/advanced/extract-authentication-parameters.md
+++ b/msal-dotnet-articles/advanced/extract-authentication-parameters.md
@@ -21,7 +21,7 @@ There are also scenarios where a web API needs more claims from the user. But gi
 
 ### Unauthenticated call to an API
 
-Some web APIs, when called unauthenticated, send back an `HTTP 401 (Unauthorized)` with a `wwwAuthenticate` header. Note that this is not a response from Azure AD, but really from a web API that the client app would call without authentication or with the wrong authentication.
+Some web APIs, when called unauthenticated, send back an `HTTP 401 (Unauthorized)` with a `wwwAuthenticate` header. Note that this is not a response from Microsoft Entra ID, but really from a web API that the client app would call without authentication or with the wrong authentication.
 
 For instance:
 

--- a/msal-dotnet-articles/advanced/high-availability.md
+++ b/msal-dotnet-articles/advanced/high-availability.md
@@ -37,9 +37,9 @@ MSAL exposes important metrics as part of [AuthenticationResult.AuthenticationRe
 
 | Metric       | Meaning     | When to trigger an alarm?    |
 | :-------------: | :----------: | :-----------: |
-|  `DurationTotalInMs`| Total time spent in MSAL, including network calls and cache   | Alarm on overall high latency (> 1 s). Value depends on token source. From the cache: one cache access. From Azure AD: two cache accesses + one HTTP call. First ever call (per-process) will take longer because of one extra HTTP call. |
+|  `DurationTotalInMs`| Total time spent in MSAL, including network calls and cache   | Alarm on overall high latency (> 1 s). Value depends on token source. From the cache: one cache access. From Microsoft Entra ID: two cache accesses + one HTTP call. First ever call (per-process) will take longer because of one extra HTTP call. |
 |  `DurationInCacheInMs` | Time spent loading or saving the token cache, which is customized by the app developer (for example, save to Redis).| Alarm on spikes. |
-|  `DurationInHttpInMs` | Time spent making HTTP calls to Azure AD.  | Alarm on spikes.|
+|  `DurationInHttpInMs` | Time spent making HTTP calls to Microsoft Entra ID.  | Alarm on spikes.|
 |  `TokenSource` | Indicates the source of the token. Tokens are retrieved from the cache much faster (for example, ~100 ms versus ~700 ms). Can be used to monitor and alarm the cache hit ratio. | Use with `DurationTotalInMs`. |
 |  `CacheRefreshReason` | Specifies the reason for fetching the access token from the identity provider. See [possible values](xref:Microsoft.Identity.Client.CacheRefreshReason). | Use with `TokenSource`. |
 
@@ -79,15 +79,15 @@ Increase application availability by issuing longer lived access tokens and ensu
 
 ### Status quo
 
-By default, Azure AD issues access tokens with 1 hour expiration. If an Azure AD outage occurs when a token needs to be refreshed, MSAL will fail. The failure propagates to the calling application and impacts availability.
+By default, Microsoft Entra ID issues access tokens with 1 hour expiration. If a Microsoft Entra outage occurs when a token needs to be refreshed, MSAL will fail. The failure propagates to the calling application and impacts availability.
 
 ### Process
 
-To improve availability MSAL tries to ensure than an app always has fresh unexpired tokens. Azure AD outages rarely take more than a few hours, so if MSAL can guarantee that a token always has at least a few hours of availability left, the application will not be impacted by the Azure AD outage. 
+To improve availability MSAL tries to ensure than an app always has fresh unexpired tokens. Microsoft Entra outages rarely take more than a few hours, so if MSAL can guarantee that a token always has at least a few hours of availability left, the application will not be impacted by the Microsoft Entra outage. 
 
 To get long lived tokens, you must configure your tenant (note: internal Microsoft tenants are already configured). For client_credentials (service 2 service), this is enough. For user credentials, you must also configure CAE - /azure/active-directory/conditional-access/concept-continuous-access-evaluation.
 
-When Azure AD returns a long lived token, it includes a `refresh_in` field. It is generally set to half the expiration of the access token.
+When Microsoft Entra ID returns a long lived token, it includes a `refresh_in` field. It is generally set to half the expiration of the access token.
 
 ![Fiddler trace of an access token request](../media/access-token-fiddler.png)
 
@@ -95,7 +95,7 @@ Note: From MSAL 4.37.0 and above, you can observe this value by inspecting the `
 
 Additionally, you can configure a token lifetime of more than the default 1 hour, as described in [Configurable token lifetimes in the Microsoft identity platform (preview)](/azure/active-directory/develop/active-directory-configurable-token-lifetimes).
 
-Whenever you make **requests for the same token**, i.e. whenever MSAL is able to serve a token from its cache, then MSAL will automatically check the `refresh_in` value. If it has elapsed, MSAL will issue a token request to Azure AD in the background, but will return the existing, valid token to the application. In the unlikely event that the background refresh fails (e.g. Azure AD outage), the app is not affected.
+Whenever you make **requests for the same token**, i.e. whenever MSAL is able to serve a token from its cache, then MSAL will automatically check the `refresh_in` value. If it has elapsed, MSAL will issue a token request to Microsoft Entra ID in the background, but will return the existing, valid token to the application. In the unlikely event that the background refresh fails (e.g. Microsoft Entra outage), the app is not affected.
 
 ## Certificate Rotation
 
@@ -115,6 +115,6 @@ This is the preferred solution for non-Microsoft internal services using ASP.NET
 
 3. (**Microsoft internal only**) Rely on Subject Name/Issuer certificates.
 
-This mechanism allows Azure AD to identify a certificate based on SN/I instead of a thumbprint (x5t). It is a stop-gap solution; there are no plans to make it available to non-Microsoft applications.
+This mechanism allows Microsoft Entra ID to identify a certificate based on SN/I instead of a thumbprint (x5t). It is a stop-gap solution; there are no plans to make it available to non-Microsoft applications.
 
 This is the preferred solution for Microsoft internal services which are not able to use managed identity.

--- a/msal-dotnet-articles/advanced/spa-authorization-code.md
+++ b/msal-dotnet-articles/advanced/spa-authorization-code.md
@@ -11,7 +11,7 @@ Today, applications using this architecture will first interactively authenticat
 
 ## Availability
 
-MSAL 4.40+ enables confidential clients to request an additional SPA auth code from the Azure AD token endpoint.
+MSAL 4.40+ enables confidential clients to request an additional SPA auth code from the Microsoft Entra token endpoint.
 
 ## Required Redirect URI setup to support the flow
 

--- a/msal-dotnet-articles/advanced/spa-authorization-code.md
+++ b/msal-dotnet-articles/advanced/spa-authorization-code.md
@@ -11,7 +11,7 @@ Today, applications using this architecture will first interactively authenticat
 
 ## Availability
 
-MSAL 4.40+ enables confidential clients to request an additional SPA auth code from the Microsoft Entra token endpoint.
+MSAL 4.40+ enables confidential clients to request an additional SPA auth code from the Microsoft Entra ID token endpoint.
 
 ## Required Redirect URI setup to support the flow
 

--- a/msal-dotnet-articles/advanced/testing-apps-using-msal.md
+++ b/msal-dotnet-articles/advanced/testing-apps-using-msal.md
@@ -41,7 +41,7 @@ Sample showcasing token cache sharing between apps: https://github.com/Azure-Sam
 
 ### Daemon apps
 
-Daemon apps use pre-deployed secrets (passwords or certificates) to talk to Azure AD. You can deploy a secret to your test environment or use the token caching technique to provision your tests. Note that the Client Credential Grant, used by daemon apps, does NOT fetch refresh tokens, just access tokens, which expire in 1h.
+Daemon apps use pre-deployed secrets (passwords or certificates) to talk to Microsoft Entra ID. You can deploy a secret to your test environment or use the token caching technique to provision your tests. Note that the Client Credential Grant, used by daemon apps, does NOT fetch refresh tokens, just access tokens, which expire in 1h.
 
 ### Native client apps
 

--- a/msal-dotnet-articles/breadcrumb/toc.yml
+++ b/msal-dotnet-articles/breadcrumb/toc.yml
@@ -2,7 +2,7 @@
   tocHref: /
   topicHref: /index
   items:
-    - name: Entra
+    - name: Microsoft Entra
       tocHref: /entra/
       topicHref: /entra/index
       items:

--- a/msal-dotnet-articles/getting-started/best-practices.md
+++ b/msal-dotnet-articles/getting-started/best-practices.md
@@ -22,9 +22,11 @@ ms.custom: devx-track-csharp, aaddev, engagement-fy23
 
 While you can have a look at the contents of an access token (for instance, using https://jwt.ms), for education, or debugging purposes, you should never parse an access token as part of your client code. The access token is only meant for the Web API or the resource it was acquired for. In most cases, web APIs use a middleware layer (for instance [Identity model extension for .NET](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki) in .NET), as this is complex code, about the protection of your web apps and Web APIs, and you don't want to introduce security vulnerabilities by forgetting some important paths.
 
-## Don't acquire tokens from Azure AD too often
+<a name='dont-acquire-tokens-from-azure-ad-too-often'></a>
 
-The standard pattern of acquiring tokens is: (i) acquire a token from the cache silently and (ii) if it doesn't work, acquire a new token from Azure AD. If you skip the first step, your app may be acquiring tokens from Azure AD too often. This provides a bad user experience, because it is slow and error prone as the identity provider might throttle you.
+## Don't acquire tokens from Microsoft Entra too often
+
+The standard pattern of acquiring tokens is: (i) acquire a token from the cache silently and (ii) if it doesn't work, acquire a new token from Microsoft Entra ID. If you skip the first step, your app may be acquiring tokens from Microsoft Entra too often. This provides a bad user experience, because it is slow and error prone as the identity provider might throttle you.
 
 ## Don't handle token expiration on your own
 

--- a/msal-dotnet-articles/getting-started/best-practices.md
+++ b/msal-dotnet-articles/getting-started/best-practices.md
@@ -24,7 +24,7 @@ While you can have a look at the contents of an access token (for instance, usin
 
 <a name='dont-acquire-tokens-from-azure-ad-too-often'></a>
 
-## Don't acquire tokens from Microsoft Entra too often
+## Don't acquire tokens from Microsoft Entra ID too often
 
 The standard pattern of acquiring tokens is: (i) acquire a token from the cache silently and (ii) if it doesn't work, acquire a new token from Microsoft Entra ID. If you skip the first step, your app may be acquiring tokens from Microsoft Entra too often. This provides a bad user experience, because it is slow and error prone as the identity provider might throttle you.
 

--- a/msal-dotnet-articles/getting-started/choosing-msal-dotnet.md
+++ b/msal-dotnet-articles/getting-started/choosing-msal-dotnet.md
@@ -44,7 +44,7 @@ You're building a confidential client application (Web app, web API, daemon/serv
   - Integrates with "App services authentication"
   - supports PKCE for confidential client applications
   - Brings performant token cache serializers, including distributed
-- Protect web API (with Microsoft Entra ID, Azure AD B2C or CIAM)
+- Protect web API (with Microsoft Entra ID, Azure AD B2C, or Microsoft Entra External ID)
   - Validates the issuer (including in-multi-tenant apps, any cloud)
   - supports token decrypt certificates in Web APIs
   - Validates Scope and app role in Web APIs

--- a/msal-dotnet-articles/getting-started/choosing-msal-dotnet.md
+++ b/msal-dotnet-articles/getting-started/choosing-msal-dotnet.md
@@ -36,7 +36,7 @@ You're building a desktop or mobile app. Use MSAL.NET directly and start acquiri
 ## Use [Microsoft Identity Web](https://github.com/AzureAD/microsoft-identity-web/)
 
 You're building a confidential client application (Web app, web API, daemon/service app) running on ASP.NET Core, ASP.NET OWIN, or .NET framework/.NET Core. See what Microsoft Identity Web has to offer:
-- Sign in users in web apps in Azure AD application, Azure AD B2C, and CIAM applications
+- Sign in users in web apps in Microsoft Entra application, Azure AD B2C, and CIAM applications
   - Support Microsoft personal accounts
   - Support guest users
   - Incremental consent and conditional access in web apps
@@ -44,7 +44,7 @@ You're building a confidential client application (Web app, web API, daemon/serv
   - Integrates with "App services authentication"
   - supports PKCE for confidential client applications
   - Brings performant token cache serializers, including distributed
-- Protect web API (with Azure AD, Azure AD B2C or CIAM)
+- Protect web API (with Microsoft Entra ID, Azure AD B2C or CIAM)
   - Validates the issuer (including in-multi-tenant apps, any cloud)
   - supports token decrypt certificates in Web APIs
   - Validates Scope and app role in Web APIs
@@ -67,7 +67,7 @@ Built the table above from this image
 
 ### You're building a new application
 
-Use the Project Templates and the `msidentity-app-sync` tool. We have web app templates for web MVC, Razor, Blazor server, Blazorwasm hosted and not hosted. All for Azure AD or Azure AD B2C.
+Use the Project Templates and the `msidentity-app-sync` tool. We have web app templates for web MVC, Razor, Blazor server, Blazorwasm hosted and not hosted. All for Microsoft Entra ID or Azure AD B2C.
 
 ![Image showing ASP.NET Core projects templates for building web apps](../media/aspnet-core-project-templates.png)
 
@@ -77,7 +77,7 @@ We have web API templates for gRPC and Azure Functions.
 
 [Web API project templates](https://github.com/AzureAD/microsoft-identity-web/wiki/web-api-template).
 
-Here's information on how to run the [msidentity-app-sync-tool](https://github.com/AzureAD/microsoft-identity-web/blob/master/tools/app-provisioning-tool/README.md) which is a command line tool which creates Microsoft identity platform applications in a tenant (Azure AD or Azure AD B2C) and updates the configuration code of your ASP.NET Core applications. The tool can also be used to update code from an existing Azure AD/Azure AD B2C application.
+Here's information on how to run the [msidentity-app-sync-tool](https://github.com/AzureAD/microsoft-identity-web/blob/master/tools/app-provisioning-tool/README.md) which is a command line tool which creates Microsoft identity platform applications in a tenant (Microsoft Entra ID or Azure AD B2C) and updates the configuration code of your ASP.NET Core applications. The tool can also be used to update code from an existing Microsoft Entra application or Azure AD B2C application.
 
 It's available on [NuGet](https://www.nuget.org/packages/msidentity-app-sync/).
 

--- a/msal-dotnet-articles/getting-started/choosing-msal-dotnet.md
+++ b/msal-dotnet-articles/getting-started/choosing-msal-dotnet.md
@@ -36,7 +36,7 @@ You're building a desktop or mobile app. Use MSAL.NET directly and start acquiri
 ## Use [Microsoft Identity Web](https://github.com/AzureAD/microsoft-identity-web/)
 
 You're building a confidential client application (Web app, web API, daemon/service app) running on ASP.NET Core, ASP.NET OWIN, or .NET framework/.NET Core. See what Microsoft Identity Web has to offer:
-- Sign in users in web apps in Microsoft Entra application, Azure AD B2C, and CIAM applications
+- Sign in users in web apps in Microsoft Entra application, Azure AD B2C, and Microsoft Entra External ID applications
   - Support Microsoft personal accounts
   - Support guest users
   - Incremental consent and conditional access in web apps

--- a/msal-dotnet-articles/getting-started/scenarios.md
+++ b/msal-dotnet-articles/getting-started/scenarios.md
@@ -27,19 +27,19 @@ As a developer, you can acquire a token from a number of **application types**, 
 - Public client applications (desktop and mobile) use the <xref:Microsoft.Identity.Client.PublicClientApplication> class
 - Confidential client applications (web apps, web APIs, and daemon applications - desktop or web). These type of apps use the <xref:Microsoft.Identity.Client.ConfidentialClientApplication>.
 
-MSAL.NET supports acquiring tokens either in the name of a **user** ![user icon](../media/user-icon.png), or, (and only for confidential client applications), in the name of the application itself (for no user). In that case the confidential client application shares a secret with Azure AD ![Azure AD icon](../media/certificate-icon.png)
+MSAL.NET supports acquiring tokens either in the name of a **user** ![user icon](../media/user-icon.png), or, (and only for confidential client applications), in the name of the application itself (for no user). In that case the confidential client application shares a secret with Microsoft Entra ID ![Microsoft Entra ID icon](../media/certificate-icon.png)
 
 MSAL.NET supports a number of **platforms** (.NET Framework, .NET Core, Windows 10/UWP, MAUI, Xamarin.iOS, Xamarin.Android). .NET Core apps can also run on different operating systems (Windows, but also Linux and MacOs). The scenarios can be different depending on the platforms.
 
 ## The Scenarios
 
-The picture below summarizes the supported scenarios and shows on which platform, and to which Azure AD protocol this corresponds:
+The picture below summarizes the supported scenarios and shows on which platform, and to which Microsoft Entra protocol this corresponds:
 
 ![Image showing supported scenarios and platforms](../media/net-oauth.png)
 
 ### Web app that signs in users and calls a web API on behalf of the user
 
-To protect a web app (signing in the user) you'll use ASP.NET or ASP.NET Core with the ASP.NET Open ID Connect middleware. This involves validating the token which is done by the [IdentityModel extensions for .NET](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki) library, not MSAL.NET.
+To protect a web app (signing in the user) you'll use ASP.NET or ASP.NET Core with the ASP.NET OpenID Connect middleware. This involves validating the token which is done by the [IdentityModel extensions for .NET](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki) library, not MSAL.NET.
 
 To call the web API in the name of the user, you'll use MSAL.NET `ConfidentialClientApplication`, leveraging the [Authorization code flow](../acquiring-tokens/web-apps-apis/authorization-codes.md), then storing the acquired token in the token cache, and [acquiring a token silently](../acquiring-tokens/acquiretokensilentasync-api.md#recommended-call-pattern-in-web-apps-using-the-authorization-code-flow-to-authenticate-the-user) from the cache when needed. MSAL refreshes the token if needed.
 
@@ -55,11 +55,11 @@ To enable this interaction, MSAL.NET leverages a [web browser](/azure/active-dir
 
 #### Protecting the app itself with Intune
 
-Your mobile app (written in Xamarin.iOS or Xamarin.Android) can have app protection policies applied to it, so that it can be [managed by InTune](/intune/app-sdk) and recognized by Intune as a managed app. The [InTune SDK](/intune/app-sdk-get-started) is separate from MSAL, and it talks to Azure AD on its own.
+Your mobile app (written in Xamarin.iOS or Xamarin.Android) can have app protection policies applied to it, so that it can be [managed by InTune](/intune/app-sdk) and recognized by Intune as a managed app. The [InTune SDK](/intune/app-sdk-get-started) is separate from MSAL, and it talks to Microsoft Entra ID on its own.
 
 ### Desktop or service daemon app that calls a web API as itself (in its own name)
 
-You can write a daemon app that acquires a token using its own identity on top using MSAL.NET's ConfidentialClientApplication's [client credentials](../acquiring-tokens/web-apps-apis/client-credential-flows.md) acquisition methods. These suppose that the app has previously registered a secret (application password or certificate) with Azure AD, which it then shares with this call.
+You can write a daemon app that acquires a token using its own identity on top using MSAL.NET's ConfidentialClientApplication's [client credentials](../acquiring-tokens/web-apps-apis/client-credential-flows.md) acquisition methods. These suppose that the app has previously registered a secret (application password or certificate) with Microsoft Entra ID, which it then shares with this call.
 
 ![Image showing a daemon app that calls a web API using its own identity](../media/net-daemon-api.png)
 
@@ -69,7 +69,7 @@ Desktop applications can use the same [interactive authentication](../acquiring-
 
 ![Image showing the flow in a desktop app that calls a web API on behalf of a signed-in user ](../media/net-desktop-api.png)
 
-For Windows hosted applications, it's also possible for applications running on computers joined to a Windows domain or Azure AD joined to acquire a token silently by using [Integrated Windows Authentication](../acquiring-tokens/desktop-mobile/integrated-windows-authentication.md).
+For Windows hosted applications, it's also possible for applications running on computers joined to a Windows domain or Microsoft Entra joined to acquire a token silently by using [Integrated Windows Authentication](../acquiring-tokens/desktop-mobile/integrated-windows-authentication.md).
 
 If your desktop application is a .NET Core application running on Linux or Mac, you can neither use the interactive authentication flow (as .NET Core does not provide a [web browser](/azure/active-directory/develop/msal-net-web-browsers)), nor Integrated Windows Authentication. The best option in that case is to use device code flow as explained in [Application without a browser, or iOT application calling an API in the name of the user](#application-without-a-browser-or-iot-application-calling-an-api-in-the-name-of-the-user).
 
@@ -102,5 +102,5 @@ Like in desktop or service daemon applications, a daemon web API (or a daemon we
 In all the scenarios you might want to:
 
 - Troubleshoot yourself by activating [logs](/azure/active-directory/develop/msal-logging-dotnet) or Telemetry
-- Understand how to react to [exceptions](../advanced/exceptions/index.md) due to the Azure AD service [`MsalServiceException`](/dotnet/api/microsoft.identity.client.msalserviceexception?view=azure-dotnet-preview#fields&preserve-view=true), or to something wrong happening in the client itself [`MsalClientException`](/dotnet/api/microsoft.identity.client.msalclientexception?view=azure-dotnet-preview#fields&preserve-view=true )
+- Understand how to react to [exceptions](../advanced/exceptions/index.md) due to the Microsoft Entra service [`MsalServiceException`](/dotnet/api/microsoft.identity.client.msalserviceexception?view=azure-dotnet-preview#fields&preserve-view=true), or to something wrong happening in the client itself [`MsalClientException`](/dotnet/api/microsoft.identity.client.msalclientexception?view=azure-dotnet-preview#fields&preserve-view=true )
 - Use MSAL.NET with a [proxy](../advanced/httpclient.md)

--- a/msal-dotnet-articles/how-to/create-config-for-mam-conditional-access.md
+++ b/msal-dotnet-articles/how-to/create-config-for-mam-conditional-access.md
@@ -15,11 +15,11 @@ This scenario includes a backend application, and an iOS and Android client appl
 
 ### Setup User and Group for testing
 
-1. Sign in to [Azure Active Directory](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview).
+1. Sign in to [Microsoft Entra ID](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview).
 2. Create a test user (e.g. `XamTestuser@XamTester.onmicrosoft.com`).
 3. On the user profile page, go to **Licenses**.
 4. Click on **Assignments** and select the following:
-    - Azure Active Directory Premium License
+    - Microsoft Entra ID P1 or P2 License
     - Enterprise Mobility + Security
     - Intune
     - Microsoft 365 Business standard
@@ -37,10 +37,10 @@ This scenario includes a backend application, and an iOS and Android client appl
 
 Register a backend application:
 
-1. In [Azure Active Directory](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview), go to Enterprise Applications section.
+1. In [Microsoft Entra ID](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview), go to Enterprise Applications section.
 2. Click on **New application**.
 3. Click **Create your own application**.
-4. Select **Register an application to integrate with Azure AD (App you're developing)** option.
+4. Select **Register an application to integrate with Microsoft Entra ID (App you're developing)** option.
 5. After **Create** screen, it will take you to **Register An Application** screen.
 6. Select **Multitenant** and click **Register**.
 7. This will take you to the screen in #1.
@@ -80,7 +80,7 @@ Configure permissions (e.e. scopes):
 
 ### Setup Client Apps
 
-1. In [Azure Active Directory](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview), go to **App registration**.
+1. In [Microsoft Entra ID](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview), go to **App registration**.
 2. Create a new app and choose **multitenant** option.
 3. Add platform URI for iOS.
 4. Add platform URI for Android.
@@ -99,13 +99,13 @@ Configure permissions (e.e. scopes):
 
 ### Build the iOS Client App
 
-1. Build a skeleton app with the client ID from the Azure AD.
+1. Build a skeleton app with the client ID from the Microsoft Entra ID.
 2. Make sure that the iOS app references **Xamarin.Intune.MAM.SDK.iOS** package.
 3. For iOS, the IPA file should be built.
 
 ### Build the Android Client App
 
-1. Build a skeleton app with the client ID from the Azure AD.
+1. Build a skeleton app with the client ID from the Microsoft Entra ID.
 2. Make sure that the Android app references **Microsoft.Intune.MAM.Xamarin.Android** package.
 3. For Android, the APK file should be built.
 

--- a/msal-dotnet-articles/how-to/differences-adal-msal-net.md
+++ b/msal-dotnet-articles/how-to/differences-adal-msal-net.md
@@ -18,7 +18,7 @@ ms.custom: devx-track-csharp, aaddev, has-adal-ref, devx-track-dotnet
 
 # Differences between ADAL.NET and MSAL.NET apps
 
-Migrating your applications from using ADAL to using MSAL comes with security and resiliency benefits. This article outlines differences between MSAL.NET and ADAL.NET. All new applications should use MSAL.NET and the Microsoft identity platform, which is the latest generation of Microsoft Authentication Libraries. Using MSAL.NET, you acquire tokens for users signing-in to your application with Azure AD (work and school accounts), Microsoft (personal) accounts (MSA), or Azure AD B2C. If you have an existing application that is using ADAL.NET, migrate it to MSAL.NET.
+Migrating your applications from using ADAL to using MSAL comes with security and resiliency benefits. This article outlines differences between MSAL.NET and ADAL.NET. All new applications should use MSAL.NET and the Microsoft identity platform, which is the latest generation of Microsoft Authentication Libraries. Using MSAL.NET, you acquire tokens for users signing-in to your application with Microsoft Entra ID (work and school accounts), Microsoft (personal) accounts (MSA), or Azure AD B2C. If you have an existing application that is using ADAL.NET, migrate it to MSAL.NET.
 
 You still need to use ADAL.NET if your application needs to sign in users with earlier versions of [Active Directory Federation Services (ADFS)](/windows-server/identity/active-directory-federation-services). For more information, see [ADFS support](https://aka.ms/msal-net-adfs-support).
 
@@ -34,9 +34,9 @@ Go through [MSAL overview](/entra/msal/overview) to learn more about MSAL.
 | **Scopes and resources**  | ADAL.NET acquires tokens for *resources*. |  MSAL.NET acquires tokens for *scopes*. Several MSAL.NET `AcquireTokenXXX` overrides require a parameter called scopes(`IEnumerable<string> scopes`). This parameter is a simple list of strings that declare the permissions and resources that are requested. Well-known scopes are the [Microsoft Graph's scopes](/graph/permissions-reference). You can also [access v1.0 resources using MSAL.NET](#scopes). |
 | **Core classes**  | ADAL.NET used [AuthenticationContext](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/AuthenticationContext:-the-connection-to-Azure-AD) as the representation of your connection to the Security Token Service (STS) or authorization server, through an Authority. | MSAL.NET is designed around [client applications](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Client-Applications). It defines `IPublicClientApplication` interfaces for public client applications and `IConfidentialClientApplication` for confidential client applications, as well as a base interface `IClientApplicationBase` for the contract common to both types of applications.|
 | **Token acquisition**  | In public clients, ADAL uses `AcquireTokenAsync` and `AcquireTokenSilentAsync` for authentication calls. | In public clients, MSAL uses `AcquireTokenInteractive` and `AcquireTokenSilent` for the same authentication calls. The parameters are different from the ADAL ones. <br><br>In Confidential client applications, there are [token acquisition methods](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Acquiring-Tokens) with an explicit name depending on the scenario. Another difference is that, in MSAL.NET, you no longer have to pass in the `ClientID` of your application in every AcquireTokenXX call. The `ClientID` is set only once when building `IPublicClientApplication` or `IConfidentialClientApplication`.|
-|  **IAccount and IUser**  | ADAL defines the notion of user through the IUser interface. However, a user is a human or a software agent. As such, a user can own one or more accounts in the Microsoft identity platform (several Azure AD accounts, Azure AD B2C, Microsoft personal accounts). The user can also be responsible for one or more Microsoft identity platform accounts. | MSAL.NET defines the concept of account (through the IAccount interface). The IAccount interface represents information about a single account. The user can have several accounts in different tenants. MSAL.NET provides better information in guest scenarios, as home account information is provided. You can read more about the [differences between IUser and IAccount](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/msal-net-2-released#iuser-is-replaced-by-iaccount).|
+|  **IAccount and IUser**  | ADAL defines the notion of user through the IUser interface. However, a user is a human or a software agent. As such, a user can own one or more accounts in the Microsoft identity platform (several Microsoft Entra accounts, Azure AD B2C, Microsoft personal accounts). The user can also be responsible for one or more Microsoft identity platform accounts. | MSAL.NET defines the concept of account (through the IAccount interface). The IAccount interface represents information about a single account. The user can have several accounts in different tenants. MSAL.NET provides better information in guest scenarios, as home account information is provided. You can read more about the [differences between IUser and IAccount](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/msal-net-2-released#iuser-is-replaced-by-iaccount).|
 |  **Cache persistence**  | ADAL.NET allows you to extend the `TokenCache` class to implement the desired persistence functionality on platforms without a secure storage (.NET Framework and .NET core) by using the `BeforeAccess`, and `BeforeWrite` methods. For details, see [token cache serialization in ADAL.NET](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/Token-cache-serialization). | MSAL.NET makes the token cache a sealed class, removing the ability to extend it. As such, your implementation of token cache persistence must be in the form of a helper class that interacts with the sealed token cache. This interaction is described in [token cache serialization in MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization) article. The serialization for a public client application (See [token cache for a public client application](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization#token-cache-for-a-public-client-application)), is different from that of for a confidential client application (See [token cache for a web app or web API](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization#token-cache-for-a-public-client-application)). |
-| **Common authority** | ADAL uses Azure AD v1.0. `https://login.microsoftonline.com/common` authority in Azure AD v1.0 (which ADAL uses) allows users to sign in using any Azure AD organization (work or school) account. Azure AD v1.0 doesn't allow sign in with Microsoft personal accounts. For more information, see [authority validation in ADAL.NET](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/AuthenticationContext:-the-connection-to-Azure-AD#authority-validation). | MSAL uses Azure AD v2.0. `https://login.microsoftonline.com/common` authority in Azure AD v2.0 (which MSAL uses) allows users to sign in with any Azure AD organization (work or school) account or with a Microsoft personal account. To restrict sign in using only organization accounts (work or school account) in MSAL, you'll need to use the `https://login.microsoftonline.com/organizations` endpoint.  For details, see the `authority` parameter in [public client application](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Client-Applications#publicclientapplication). |
+| **Common authority** | ADAL uses Azure AD v1.0. `https://login.microsoftonline.com/common` authority in Azure AD v1.0 (which ADAL uses) allows users to sign in using any Microsoft Entra organization (work or school) account. Azure AD v1.0 doesn't allow sign in with Microsoft personal accounts. For more information, see [authority validation in ADAL.NET](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/AuthenticationContext:-the-connection-to-Azure-AD#authority-validation). | MSAL uses Azure AD v2.0. `https://login.microsoftonline.com/common` authority in Azure AD v2.0 (which MSAL uses) allows users to sign in with any Microsoft Entra organization (work or school) account or with a Microsoft personal account. To restrict sign in using only organization accounts (work or school account) in MSAL, you'll need to use the `https://login.microsoftonline.com/organizations` endpoint.  For details, see the `authority` parameter in [public client application](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Client-Applications#publicclientapplication). |
 
 ## Supported grants
 
@@ -130,7 +130,7 @@ An access token and an ID token are returned in the `AuthenticationResult` value
 
 There are two versions of tokens: v1.0 tokens and  v2.0 tokens. The v1.0 endpoint (used by ADAL) emits v1.0 ID tokens while the v2.0 endpoint (used by MSAL) emits v2.0 ID tokens. However, both endpoints emit access tokens of the version of the token that the web API accepts. A property of the application manifest of the web API enables developers to choose which version of token is accepted. See `accessTokenAcceptedVersion` in the [application manifest](/azure/active-directory/develop/reference-app-manifest) reference documentation.
 
-For more information about v1.0 and v2.0 access tokens, see [Azure Active Directory access tokens](/azure/active-directory/develop/access-tokens).
+For more information about v1.0 and v2.0 access tokens, see [Microsoft Entra access tokens](/azure/active-directory/develop/access-tokens).
 
 ## Exceptions
 
@@ -168,7 +168,7 @@ Prompt behavior in MSAL.NET is equivalent to prompt behavior in ADAL.NET:
 
 |  ADAL.NET | MSAL.NET | Description |
 | ----------- | ----------- | -------------|
-| `PromptBehavior.Auto`| `NoPrompt`| Azure AD chooses the best behavior (signing in users silently if they are signed in with only one account, or displaying the account selector if they are signed in with several accounts). |
+| `PromptBehavior.Auto`| `NoPrompt`| Microsoft Entra ID chooses the best behavior (signing in users silently if they are signed in with only one account, or displaying the account selector if they are signed in with several accounts). |
 | `PromptBehavior.Always`| `ForceLogin` | Resets the sign-in box and forces the user to reenter their credentials. |
 | `PromptBehavior.RefreshSession`| `Consent`| Forces the user to consent again to all permissions. |
 | `PromptBehavior.Never`| `Never`| Don't use; instead, use the [recommended pattern for public client apps](/azure/active-directory/develop/scenario-desktop-acquire-token?tabs=dotnet). |
@@ -176,7 +176,7 @@ Prompt behavior in MSAL.NET is equivalent to prompt behavior in ADAL.NET:
 
 ### Handling claim challenge exceptions
 
-At times when acquiring a token, Azure AD throws an exception in case a resource requires more claims from the user (for instance two-factor authentication).
+At times when acquiring a token, Microsoft Entra ID throws an exception in case a resource requires more claims from the user (for instance two-factor authentication).
 
 In MSAL.NET, claim challenge exceptions are handled in the following way:
 
@@ -195,11 +195,11 @@ For details, including samples see [handling AdalClaimChallengeException](https:
 
 ## Scopes
 
-ADAL uses the concept of resources with `resourceId` string, MSAL.NET, however, uses scopes. The logic used by Azure AD is as follows:
+ADAL uses the concept of resources with `resourceId` string, MSAL.NET, however, uses scopes. The logic used by Microsoft Entra ID is as follows:
 
 - For ADAL (v1.0) endpoint with a v1.0 access token (the only possible), `aud=resource`.
 - For MSAL (v2.0 endpoint) asking an access token for a resource accepting v2.0 tokens, `aud=resource.AppId`.
-- For MSAL (v2.0 endpoint) asking an access token for a resource accepting a v1.0 access token, Azure AD parses the desired audience from the requested scope. This is done by taking everything before the last slash and using it as the resource identifier. As such, if `https://database.windows.net` expects an audience of `https://database.windows.net/`, you'll need to request a scope of `https://database.windows.net//.default` (notice the double slash before ./default). This is illustrated by examples 1 and 2 below.
+- For MSAL (v2.0 endpoint) asking an access token for a resource accepting a v1.0 access token, Microsoft Entra ID parses the desired audience from the requested scope. This is done by taking everything before the last slash and using it as the resource identifier. As such, if `https://database.windows.net` expects an audience of `https://database.windows.net/`, you'll need to request a scope of `https://database.windows.net//.default` (notice the double slash before ./default). This is illustrated by examples 1 and 2 below.
 
 ### Example 1
 
@@ -211,7 +211,7 @@ For instance, to access the name of the user via a v1.0 web API whose App ID URI
 var scopes = new [] { ResourceId+"/user_impersonation" };
 ```
 
-If you want to read and write with MSAL.NET Azure Active Directory using the Microsoft Graph API (`https://graph.microsoft.com/`), you'd create a list of scopes like in the code snippet below:
+If you want to read and write with MSAL.NET Microsoft Entra ID using the Microsoft Graph API (`https://graph.microsoft.com/`), you'd create a list of scopes like in the code snippet below:
 
 ```csharp
 string ResourceId = "https://graph.microsoft.com/"; 
@@ -239,7 +239,7 @@ ResourceId = "someAppIDURI";
 var scopes = new [] { ResourceId+"/.default" };
 ```
 
-For a client credential flow, the scope to pass would also be `/.default`. This scope tells to Azure AD: "all the app-level permissions that the admin has consented to in the application registration.
+For a client credential flow, the scope to pass would also be `/.default`. This scope tells to Microsoft Entra ID: "all the app-level permissions that the admin has consented to in the application registration.
 
 ## Next steps
 

--- a/msal-dotnet-articles/how-to/migrate-confidential-client.md
+++ b/msal-dotnet-articles/how-to/migrate-confidential-client.md
@@ -499,7 +499,7 @@ Key benefits of MSAL.NET for your app include:
 
 - **Resilience**. MSAL.NET helps make your app resilient through:
 
-  - Azure AD Cached Credential Service (CCS) benefits. CCS operates as an Azure AD backup.
+  - Microsoft Entra ID Cached Credential Service (CCS) benefits. CCS operates as a Microsoft Entra backup.
   - Proactive renewal of tokens if the API that you call enables long-lived tokens through [continuous access evaluation](/azure/active-directory/develop/app-resilience-continuous-access-evaluation).
 
 - **Security**. You can acquire Proof of Possession (PoP) tokens if the web API that you want to call requires it. For details, see [Proof Of Possession tokens in MSAL.NET](../advanced/proof-of-possession-tokens.md)

--- a/msal-dotnet-articles/how-to/migrate-public-client.md
+++ b/msal-dotnet-articles/how-to/migrate-public-client.md
@@ -37,7 +37,7 @@ This article describes how to migrate a public client application from Azure Act
 
    - [Web Authentication Manager](/azure/active-directory/develop/scenario-desktop-acquire-token-wam) the preferred broker-based authentication on Windows.
    - [Interactive authentication](/azure/active-directory/develop/scenario-desktop-acquire-token-interactive) where the user is shown a web-based interface to complete the sign-in process.
-   - [Integrated Windows authentication](/azure/active-directory/develop/scenario-desktop-acquire-token-integrated-windows-authentication) where a user signs using the same identity they used to sign into a Windows domain (for domain-joined or Azure AD-joined machines).
+   - [Integrated Windows authentication](/azure/active-directory/develop/scenario-desktop-acquire-token-integrated-windows-authentication) where a user signs using the same identity they used to sign into a Windows domain (for domain-joined or Microsoft Entra joined machines).
    - [Username/password](/azure/active-directory/develop/scenario-desktop-acquire-token-username-password) where the sign-in occurs by providing a username/password credential.
    - [Device code flow](/azure/active-directory/develop/scenario-desktop-acquire-token-device-code-flow) where a device of limited UX shows you a device code to complete the authentication flow on an alternate device.
 
@@ -120,7 +120,7 @@ The MSAL code shown above uses WAM (Web authentication manager) which is the rec
 
 ## [Integrated Windows authentication](#tab/iwa)
 
-Integrated Windows authentication is where your public client application signs in using the same identity they used to sign into a Windows domain (for domain-joined or Azure AD-joined machines).
+Integrated Windows authentication is where your public client application signs in using the same identity they used to sign into a Windows domain (for domain-joined or Microsoft Entra joined machines).
 
 #### Find out if your code uses integrated Windows authentication
 
@@ -469,7 +469,7 @@ Key benefits of MSAL.NET for your app include:
 
 - **Resilience**. MSAL.NET helps make your app resilient through the following:
 
-   - Azure AD Cached Credential Service (CCS) benefits. CCS operates as an Azure AD backup.
+   - Microsoft Entra ID Cached Credential Service (CCS) benefits. CCS operates as a Microsoft Entra backup.
    - Proactive renewal of tokens if the API that you call enables long-lived tokens through [continuous access evaluation](/azure/active-directory/develop/app-resilience-continuous-access-evaluation).
 
 ### Troubleshooting

--- a/msal-dotnet-articles/how-to/msal-net-migration.md
+++ b/msal-dotnet-articles/how-to/msal-net-migration.md
@@ -20,7 +20,7 @@ ms.custom: devx-track-csharp, aaddev, has-adal-ref, engagement-fy23, devx-track-
 
 ## Why migrate to MSAL.NET or Microsoft.Identity.Web
 
-Both the Microsoft Authentication Library for .NET (MSAL.NET) and Azure AD Authentication Library for .NET (ADAL.NET) are used to authenticate Azure AD entities and request tokens from Azure AD. Up until now, most developers have requested tokens from Azure AD for developers platform (v1.0) using Azure AD Authentication Library (ADAL). These tokens are used to authenticate Azure AD identities (work and school accounts). 
+Both the Microsoft Authentication Library for .NET (MSAL.NET) and Azure AD Authentication Library for .NET (ADAL.NET) are used to authenticate Microsoft Entra entities and request tokens from Microsoft Entra ID. Up until now, most developers have requested tokens from Azure AD for developers platform (v1.0) using Azure AD Authentication Library (ADAL). These tokens are used to authenticate Microsoft Entra identities (work and school accounts). 
 
 MSAL comes with benefits over ADAL. Some of these benefits are listed below:
 

--- a/msal-dotnet-articles/how-to/overriding-authority.md
+++ b/msal-dotnet-articles/how-to/overriding-authority.md
@@ -5,7 +5,7 @@ description: "How to override the default authority in MSAL.NET applications."
 
 # Overriding authority
 
-In many scenarios, such as [client credential flow in multi-tenant apps](../advanced/client-credential-multi-tenant.md), it is useful to specify the Azure AD tenant in the request builder instead of the application builder. `WithTenantId` is the recommended API to use in this scenario, which accepts the tenant ID string. `WithTenantIdFromAuthority` is another similar method that is available in MSAL 4.46.0+. You can also use `WithAuthority`, however, the authority in the application and the request builders must always be for the same cloud, i.e. the host of the authority URL must not be different.
+In many scenarios, such as [client credential flow in multi-tenant apps](../advanced/client-credential-multi-tenant.md), it is useful to specify the Microsoft Entra tenant in the request builder instead of the application builder. `WithTenantId` is the recommended API to use in this scenario, which accepts the tenant ID string. `WithTenantIdFromAuthority` is another similar method that is available in MSAL 4.46.0+. You can also use `WithAuthority`, however, the authority in the application and the request builders must always be for the same cloud, i.e. the host of the authority URL must not be different.
 
 ```csharp
 var app =  ConfidentialClientApplicationBuilder

--- a/msal-dotnet-articles/how-to/protect-ios-android-mam-intune.md
+++ b/msal-dotnet-articles/how-to/protect-ios-android-mam-intune.md
@@ -9,13 +9,13 @@ description: "How to use InTune with Android and iOS applications that depend on
 
 There are scenarios when just user authentication may not be sufficient to protect certain resources. The device that accesses it should also be compliant as per policies defined in InTune.
 
-Azure Active Directory (Azure AD) ensures that the access token is not issued till the device is compliant as per the conditional access policy. This page explains how a resource can be reached by MSAL.NET while being protected by InTune [Mobile Application Management (MAM)](/mem/intune/fundamentals/deployment-guide-enrollment-mamwe).
+Microsoft Entra ID ensures that the access token is not issued till the device is compliant as per the conditional access policy. This page explains how a resource can be reached by MSAL.NET while being protected by InTune [Mobile Application Management (MAM)](/mem/intune/fundamentals/deployment-guide-enrollment-mamwe).
 
 ## Overview of the system configuration
 
 The system comprises of two apps: a backend app that provides access to a hosted resource and a client App that needs to access the resource.The resource is defined by scope. When the client app needs the resource, it will request access to the scope.  
 
-Azure Active Directory (Azure AD) protects the resource by applying conditional access on the resource. One of the conditions of the access is to have App Protection Policy on the client App.  
+Microsoft Entra ID protects the resource by applying conditional access on the resource. One of the conditions of the access is to have App Protection Policy on the client App.  
 
 An App protection policy can be created in the InTune Portal for an App and it can be applied to one or more user groups.  
 
@@ -23,7 +23,7 @@ Here are the detail [setup steps](./create-config-for-mam-conditional-access.md)
 
 ## Workflow for iOS
 
-As a result of the setup, when App attempts to reach the resource and if the device is not compliant, Azure AD returns `protection_policy_required` sub-error.  
+As a result of the setup, when App attempts to reach the resource and if the device is not compliant, Microsoft Entra ID returns `protection_policy_required` sub-error.  
 
 MSAL.NET catches the error and throw `IntuneAppProtectionPolicyRequiredException`.  
 
@@ -124,7 +124,7 @@ The complete sample can be found [on GitHub](https://github.com/AzureAD/microsof
 
 ## Workflow for Android
 
-As a result of the setup, when App attempts to reach the resource and if the device is not compliant, Azure AD returns `protection_policy_required` suberror.  
+As a result of the setup, when App attempts to reach the resource and if the device is not compliant, Microsoft Entra ID returns `protection_policy_required` suberror.  
 
 MSAL.NET catches the error and throws `IntuneAppProtectionPolicyRequiredException`.  
 

--- a/msal-dotnet-articles/how-to/token-cache-serialization.md
+++ b/msal-dotnet-articles/how-to/token-cache-serialization.md
@@ -378,11 +378,11 @@ var app = ConfidentialClientApplicationBuilder
 
 ## [Desktop apps](#tab/desktop)
 
-In desktop applications, we recommend that you use the cross-platform token cache. MSAL.NET provides the cross-platform token cache in a separate library named [Microsoft.Identity.Client.Extensions.Msal](https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet).
+In desktop applications, we recommend that you use the cross-platform token cache. MSAL.NET provides the cross-platform token cache in a separate library named [Microsoft.Identity.Client.Extensions.MSAL](https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet).
 
 #### Referencing the NuGet package
 
-Add the [Microsoft.Identity.Client.Extensions.Msal](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal/) NuGet package to your project.
+Add the [Microsoft.Identity.Client.Extensions.MSAL](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal/) NuGet package to your project.
 
 #### Configuring the token cache
 
@@ -539,7 +539,7 @@ static class TokenCacheHelper
  }
 ```
 
-A product-quality, file-based token cache serializer for public client applications (for desktop applications running on Windows, Mac, and Linux) is available from the [Microsoft.Identity.Client.Extensions.Msal](https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/tree/master/src/Microsoft.Identity.Client.Extensions.Msal) open-source library. You can include it in your applications from the following NuGet package: [Microsoft.Identity.Client.Extensions.Msal](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal/).
+A product-quality, file-based token cache serializer for public client applications (for desktop applications running on Windows, Mac, and Linux) is available from the [Microsoft.Identity.Client.Extensions.MSAL](https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/tree/master/src/Microsoft.Identity.Client.Extensions.Msal) open-source library. You can include it in your applications from the following NuGet package: [Microsoft.Identity.Client.Extensions.MSAL](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal/).
 
 #### Dual token cache serialization (MSAL unified cache)
 
@@ -553,9 +553,9 @@ MSAL exposes important metrics as part of [AuthenticationResult.AuthenticationRe
 
 | Metric       | Meaning     | When to trigger an alarm?    |
 | :-------------: | :----------: | :-----------: |
-|  `DurationTotalInMs` | Total time spent in MSAL, including network calls and cache.   | Alarm on overall high latency (> 1 second). Value depends on token source. From the cache: one cache access. From Azure Active Directory (Azure AD): two cache accesses plus one HTTP call. First ever call (per-process) takes longer because of one extra HTTP call. |
+|  `DurationTotalInMs` | Total time spent in MSAL, including network calls and cache.   | Alarm on overall high latency (> 1 second). Value depends on token source. From the cache: one cache access. From Microsoft Entra ID: two cache accesses plus one HTTP call. First ever call (per-process) takes longer because of one extra HTTP call. |
 |  `DurationInCacheInMs` | Time spent loading or saving the token cache, which is customized by the app developer (for example, save to Redis).| Alarm on spikes. |
-|  `DurationInHttpInMs`| Time spent making HTTP calls to Azure AD.  | Alarm on spikes.|
+|  `DurationInHttpInMs`| Time spent making HTTP calls to Microsoft Entra ID.  | Alarm on spikes.|
 |  `TokenSource` | Source of the token. Tokens are retrieved from the cache much faster (for example, ~100 ms versus ~700 ms). Can be used to monitor and alarm the cache hit ratio. | Use with `DurationTotalInMs`. |
 |  `CacheRefreshReason` | Reason for fetching the access token from the identity provider. | Use with `TokenSource`. |
 
@@ -589,6 +589,6 @@ The following samples illustrate token cache serialization.
 
 | Sample | Platform | Description|
 | ------ | -------- | ----------- |
-|[active-directory-dotnet-desktop-msgraph-v2](https://github.com/azure-samples/active-directory-dotnet-desktop-msgraph-v2) | Desktop (WPF) | Windows Desktop .NET (WPF) application that calls the Microsoft Graph API. ![Diagram that shows a topology with a desktop app client flowing to Azure Active Directory by acquiring a token interactively and to Microsoft Graph.](../media/msal-net-token-cache-serialization/topology.png)|
+|[active-directory-dotnet-desktop-msgraph-v2](https://github.com/azure-samples/active-directory-dotnet-desktop-msgraph-v2) | Desktop (WPF) | Windows Desktop .NET (WPF) application that calls the Microsoft Graph API. ![Diagram that shows a topology with a desktop app client flowing to Microsoft Entra ID by acquiring a token interactively and to Microsoft Graph.](../media/msal-net-token-cache-serialization/topology.png)|
 |[active-directory-dotnet-v1-to-v2](https://github.com/Azure-Samples/active-directory-dotnet-v1-to-v2) | Desktop (console) | Set of Visual Studio solutions that illustrate the migration of Azure AD v1.0 applications (using ADAL.NET) to Microsoft identity platform applications (using MSAL.NET). In particular, see [Token cache migration](https://github.com/Azure-Samples/active-directory-dotnet-v1-to-v2/blob/master/TokenCacheMigration/README.md) and [Confidential client token cache](https://github.com/Azure-Samples/active-directory-dotnet-v1-to-v2/tree/master/ConfidentialClientTokenCache). |
 [ms-identity-aspnet-webapp-openidconnect](https://github.com/Azure-Samples/ms-identity-aspnet-webapp-openidconnect) | ASP.NET (net472) | Example of token cache serialization in an ASP.NET MVC application (using MSAL.NET).

--- a/msal-dotnet-articles/how-to/token-cache-serialization.md
+++ b/msal-dotnet-articles/how-to/token-cache-serialization.md
@@ -382,7 +382,7 @@ In desktop applications, we recommend that you use the cross-platform token cach
 
 #### Referencing the NuGet package
 
-Add the [Microsoft.Identity.Client.Extensions.MSAL](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal/) NuGet package to your project.
+Add the [Microsoft.Identity.Client.Extensions.Msal](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal/) NuGet package to your project.
 
 #### Configuring the token cache
 

--- a/msal-dotnet-articles/how-to/token-cache-serialization.md
+++ b/msal-dotnet-articles/how-to/token-cache-serialization.md
@@ -539,7 +539,7 @@ static class TokenCacheHelper
  }
 ```
 
-A product-quality, file-based token cache serializer for public client applications (for desktop applications running on Windows, Mac, and Linux) is available from the [Microsoft.Identity.Client.Extensions.MSAL](https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/tree/master/src/Microsoft.Identity.Client.Extensions.Msal) open-source library. You can include it in your applications from the following NuGet package: [Microsoft.Identity.Client.Extensions.MSAL](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal/).
+A product-quality, file-based token cache serializer for public client applications (for desktop applications running on Windows, Mac, and Linux) is available from the [Microsoft.Identity.Client.Extensions.Msal](https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/tree/master/src/Microsoft.Identity.Client.Extensions.Msal) open-source library. You can include it in your applications from the following NuGet package: [Microsoft.Identity.Client.Extensions.Msal](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal/).
 
 #### Dual token cache serialization (MSAL unified cache)
 

--- a/msal-dotnet-articles/includes/error-handling-introduction.md
+++ b/msal-dotnet-articles/includes/error-handling-introduction.md
@@ -14,7 +14,7 @@ This article gives an overview of the different types of errors and recommendati
 
 Exceptions in Microsoft Authentication Library (MSAL) are intended for app developers to troubleshoot, not for displaying to end users. Exception messages are not localized.
 
-When processing exceptions and errors, you can use the exception type itself and the error code to distinguish between exceptions. For a list of error codes, see [Azure AD Authentication and authorization error codes](/azure/active-directory/develop/reference-error-codes).
+When processing exceptions and errors, you can use the exception type itself and the error code to distinguish between exceptions. For a list of error codes, see [Microsoft Entra authentication and authorization error codes](/azure/active-directory/develop/reference-error-codes).
 
 During the sign-in experience, you may encounter errors about consents, Conditional Access (MFA, Device Management, Location-based restrictions), token issuance and redemption, and user properties.
 

--- a/msal-dotnet-articles/includes/error-handling-retries.md
+++ b/msal-dotnet-articles/includes/error-handling-retries.md
@@ -10,7 +10,7 @@ ms.topic: include
 ---
 ## Retrying after errors and exceptions
 
-You're expected to implement your own retry policies when calling MSAL. MSAL makes HTTP calls to the Azure AD service, and occasionally failures can occur. For example the network can go down or the server is overloaded.  
+You're expected to implement your own retry policies when calling MSAL. MSAL makes HTTP calls to the Microsoft Entra service, and occasionally failures can occur. For example the network can go down or the server is overloaded.  
 
 ### HTTP 429
 

--- a/msal-dotnet-articles/index.md
+++ b/msal-dotnet-articles/index.md
@@ -18,7 +18,7 @@ ms.custom: devx-track-csharp, aaddev, engagement-fy23
 
 # Microsoft Authentication Library for .NET
 
-MSAL.NET ([Microsoft.Identity.Client](https://www.nuget.org/packages/Microsoft.Identity.Client)) is an authentication library that enables you to acquire tokens from Azure Active Directory (Azure AD), to access protected web APIs (Microsoft APIs or applications registered with Azure AD). MSAL.NET is available on several .NET platforms (Desktop, Universal Windows Platform, MAUI, Xamarin Android, Xamarin iOS, Windows 8.1, and .NET Core).
+MSAL.NET ([Microsoft.Identity.Client](https://www.nuget.org/packages/Microsoft.Identity.Client)) is an authentication library that enables you to acquire tokens from Microsoft Entra ID, to access protected web APIs (Microsoft APIs or applications registered with Microsoft Entra ID). MSAL.NET is available on several .NET platforms (Desktop, Universal Windows Platform, MAUI, Xamarin Android, Xamarin iOS, Windows 8.1, and .NET Core).
 
 > [!div class="nextstepaction"]
 > [Get MSAL.NET >](https://www.nuget.org/packages/Microsoft.Identity.Client/)
@@ -58,10 +58,10 @@ As a token acquisition library, MSAL.NET provides several ways of getting a toke
 
 ### MSAL.NET is about acquiring tokens, not protecting an API
 
-MSAL.NET is used to acquire tokens. It's not used to protect a Web API. If you are interested in protecting a Web API with Azure AD, you might want to check out:
+MSAL.NET is used to acquire tokens. It's not used to protect a Web API. If you are interested in protecting a Web API with Microsoft Entra ID, you might want to check out:
 
-- [Azure Active Directory with ASP.NET Core](/aspnet/core/security/authentication/azure-active-directory/). Note that some of these examples present web apps which also call a web API with MSAL.NET.
-- [Active-directory-dotnet-native-aspnetcore-v2](https://github.com/azure-samples/active-directory-dotnet-native-aspnetcore-v2) which shows how to call an ASP.NET Core Web API from a WPF application using Azure AD V2.
+- [Microsoft Entra ID with ASP.NET Core](/aspnet/core/security/authentication/azure-active-directory/). Note that some of these examples present web apps which also call a web API with MSAL.NET.
+- [Active-directory-dotnet-native-aspnetcore-v2](https://github.com/azure-samples/active-directory-dotnet-native-aspnetcore-v2) which shows how to call an ASP.NET Core Web API from a WPF application using Azure AD v2.
 - The [IdentityModel extensions for .Net](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet) open source library providing middleware used by ASP.NET and ASP.NET Core to protect APIs.
 
 ## Conceptual documentation
@@ -69,7 +69,7 @@ MSAL.NET is used to acquire tokens. It's not used to protect a Web API. If you a
 ### Getting started with MSAL.NET
 
 1. Learn about [MSAL.NET usage scenarios](./getting-started/scenarios.md).
-1. You will need to [register your app](/azure/active-directory/develop/quickstart-register-app) with Azure Active Directory.
+1. You will need to [register your app](/azure/active-directory/develop/quickstart-register-app) with Microsoft Entra ID.
 1. Learn about the [types of client applications](/azure/active-directory/develop/msal-client-applications): public client and confidential client.
 1. Learn about [acquiring tokens](acquiring-tokens/overview.md) to access a protected API.
 
@@ -82,7 +82,7 @@ MSAL.NET is used to acquire tokens. It's not used to protect a Web API. If you a
 #### Acquiring tokens in desktop and mobile apps (public client applications)
 
 - [Acquiring a token interactively](acquiring-tokens/desktop-mobile/acquiring-tokens-interactively.md) enables the application to acquire a token after authenticating the user through an interactive sign-in. There are implementation-specific details depending on the target platforms, such as [Xamarin Android](acquiring-tokens/desktop-mobile/xamarin.md) or [UWP](acquiring-tokens/desktop-mobile/uwp.md).
-- Acquiring a token silently on a Windows domain or Azure Active Directory joined machine with [Integrated Windows Authentication](./acquiring-tokens/desktop-mobile/integrated-windows-authentication.md) or by using [Username/passwords](./acquiring-tokens/desktop-mobile/username-password-authentication.md) (not recommended).
+- Acquiring a token silently on a Windows domain or Microsoft Entra joined machine with [Integrated Windows Authentication](./acquiring-tokens/desktop-mobile/integrated-windows-authentication.md) or by using [Username/passwords](./acquiring-tokens/desktop-mobile/username-password-authentication.md) (not recommended).
 - Acquiring a token on a text-only device, by directing the user to sign-in on another device with the [Device Code Flow](./acquiring-tokens/desktop-mobile/device-code-flow.md).
 - Acquiring a token using the [Web Account Manager (WAM)](./acquiring-tokens/desktop-mobile/wam.md), a Windows OS component that acts a broker allowing the users of your app benefit from integration with accounts known to Windows.
 

--- a/msal-dotnet-articles/microsoft-identity-web/index.md
+++ b/msal-dotnet-articles/microsoft-identity-web/index.md
@@ -22,7 +22,7 @@ Microsoft Identity Web is a set of ASP.NET Core libraries that simplifies adding
 
 ## Supported application scenarios
 
-When building ASP.NET Core web apps or web APIs that use Azure Active Directory (Azure AD) or Azure AD B2C for identity and access management (IAM), Microsoft Identity Web is recommended for these scenarios:
+When building ASP.NET Core web apps or web APIs that use Microsoft Entra ID or Azure AD B2C for identity and access management (IAM), Microsoft Identity Web is recommended for these scenarios:
 
 - [Service/Daemon applications](/azure/active-directory/develop/scenario-daemon-overview)
 - [Web app that signs in users](/azure/active-directory/develop/scenario-web-app-sign-user-overview)
@@ -75,7 +75,7 @@ dotnet new webapp --auth SingleOrg --calls-graph --client-id "00000000-0000-0000
 ### Getting started with MSAL.NET
 
 1. Learn about [Scenarios](./getting-started/scenarios.md).
-1. You will need to [register your app](/azure/active-directory/develop/quickstart-register-app) with Azure Active Directory.
+1. You will need to [register your app](/azure/active-directory/develop/quickstart-register-app) with Microsoft Entra ID.
 
 ## Samples
 

--- a/msal-dotnet-articles/resources/region-discovery-troubleshooting.md
+++ b/msal-dotnet-articles/resources/region-discovery-troubleshooting.md
@@ -4,6 +4,6 @@ title: Region discovery troubleshooting
 
 # Region discovery troubleshooting
 
-Azure AD has adding support for regional STS (ESTS-Regional). Currently only the service to service flow (client_credentials / AcquireTokenForClient) is available via opt-in only to first party apps.
+Microsoft Entra ID has adding support for regional STS (ESTS-Regional). Currently only the service to service flow (client_credentials / AcquireTokenForClient) is available via opt-in only to first party apps.
 
 For more details refer to [internal guidance](https://aka.ms/msal/estsr/guidance).

--- a/msal-dotnet-articles/resources/telemetry-overview.md
+++ b/msal-dotnet-articles/resources/telemetry-overview.md
@@ -1,11 +1,11 @@
 ---
 title: MSAL.NET telemetry overview
-description: Explore MSAL.NET's telemetry capabilities for Azure AD token endpoint requests. Learn about client-side state, error tracking, and SDK API usage metadata.
+description: Explore MSAL.NET's telemetry capabilities for Microsoft Entra token endpoint requests. Learn about client-side state, error tracking, and SDK API usage metadata.
 ---
 
 # MSAL.NET telemetry overview
 
-MSAL.NET sends basic telemetry about the client side state on requests to the Azure AD token endpoint. Telemetry data will be logged by Azure AD. This telemetry will give us visibility into both 1st and 3rd party app health without introducing an additional telemetry pipeline dependency into the open source SDK. MSAL.NET collects this telemetry to proactively detect server side failures or library regressions, in order to provide a better service.
+MSAL.NET sends basic telemetry about the client side state on requests to the Microsoft Entra token endpoint. Telemetry data will be logged by Microsoft Entra ID. This telemetry will give us visibility into both 1st and 3rd party app health without introducing an additional telemetry pipeline dependency into the open source SDK. MSAL.NET collects this telemetry to proactively detect server side failures or library regressions, in order to provide a better service.
 
 Basic telemetry includes:
 


### PR DESCRIPTION
Applying Azure AD rebranding changes as announced on July 11, 2023 and outlined in https://aka.ms/AzureADNewName. Changes are part of the Microsoft-wide rebranding effort.

CorrelationId: 2520d58e-25ff-469e-af14-2834d2a1505e
PointOfContact: @CelesteDG

#docutune
