### PR TITLE
Removed not recommended use of SecurePassword from example of AcquireTokenByUsernamePassword

### DIFF
--- a/msal-dotnet-articles/acquiring-tokens/desktop-mobile/username-password-authentication.md
+++ b/msal-dotnet-articles/acquiring-tokens/desktop-mobile/username-password-authentication.md
@@ -82,10 +82,7 @@ static async Task GetATokenForGraph()
     {
         try
         {
-            var securePassword = new SecureString();
-            foreach(char c in "dummy") // you should fetch the password keystroke
-            securePassword.AppendChar(c); // by keystroke
-            result = await app.AcquireTokenByUsernamePassword(scopes, "joe@contoso.com", securePassword).ExecuteAsync();
+            result = await app.AcquireTokenByUsernamePassword(scopes, "joe@contoso.com", "joepassword").ExecuteAsync();
         }
         catch (MsalException)
         {


### PR DESCRIPTION
In the documentation's example of AcquireTokenByUsernamePassword it uses the SecurePassword class but it's not recommended by documentation. Just a small detail, but to make it more cohesive with the documentation, I thought this version was better.