### PR TITLE
Update the reference grouping

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -39,7 +39,10 @@
         {
             "source_path": "msal-dotnet-articles/acquiring-tokens/user-gets-consent-for-multiple-resources.md",
             "redirect_url": "/entra/msal/dotnet/acquiring-tokens/desktop-mobile/acquiring-tokens-interactively"
+        },
+        {
+            "source_path": "dotnet/api/microsoft-authentication-library-dotnet/ConfidentialClient.yml",
+            "redirect_url": "/dotnet/api/microsoft-authentication-library-dotnet/higher-levellibraries"
         }
-
     ]
 }

--- a/dotnet/api/overview/index.md
+++ b/dotnet/api/overview/index.md
@@ -19,7 +19,7 @@ Check out the [scenario overview](/entra/msal/dotnet/getting-started/scenarios) 
 
 [![NuGet badget for Microsoft.Identity.Client.Desktop](https://img.shields.io/nuget/v/Microsoft.Identity.Client.Desktop.svg?style=flat-square&label=Microsoft.Identity.Client.Desktop&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client.Desktop/)
 
-[![NuGet badget for Microsoft.Identity.Client.Extensions.Msal](https://img.shields.io/nuget/v/Microsoft.Identity.Client.Extensions.Msal.svg?style=flat-square&label=Microsoft.Identity.Client.Extensions.Msal&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal/)
+[![NuGet badge for Microsoft.Identity.Client.Extensions.Msal](https://img.shields.io/nuget/v/Microsoft.Identity.Client.Extensions.Msal.svg?style=flat-square&label=Microsoft.Identity.Client.Extensions.Msal&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal/)
 
 ### Higher-Level Libraries
 

--- a/dotnet/api/overview/index.md
+++ b/dotnet/api/overview/index.md
@@ -11,7 +11,7 @@ Check out the [scenario overview](/entra/msal/dotnet/getting-started/scenarios) 
 
 ## Packages
 
-### Public Client
+### Core MSAL.NET Libraries
 
 [![NuGet badge for Microsoft.Identity.Client](https://img.shields.io/nuget/v/Microsoft.Identity.Client.svg?style=flat-square&label=Microsoft.Identity.Client&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client/)
 
@@ -21,7 +21,7 @@ Check out the [scenario overview](/entra/msal/dotnet/getting-started/scenarios) 
 
 [![NuGet badget for Microsoft.Identity.Client.Extensions.Msal](https://img.shields.io/nuget/v/Microsoft.Identity.Client.Extensions.Msal.svg?style=flat-square&label=Microsoft.Identity.Client.Extensions.Msal&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal/)
 
-### Confidential Client
+### Higher-Level Libraries
 
 [![NuGet badge for Microsoft.Identity.Web](https://img.shields.io/nuget/v/Microsoft.Identity.Web.svg?style=flat-square&label=Microsoft.Identity.Web&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Web/)
 

--- a/dotnet/api/overview/msal-public-client/index.md
+++ b/dotnet/api/overview/msal-public-client/index.md
@@ -15,7 +15,7 @@ MSAL.NET enables the development of public client applications with the help of 
 
 ## Confidential client applications
 
-Confidential client applications are apps that run on servers, such as web apps, web API apps, or service/daemon apps. Their internals are considered difficult to access, and therefore they can keep an application secret secure and out of sight of its users. Confidential clients can hold configuration-time secrets. The concept, just like public client applicatrions, also is following the definitions included in [RFC6749 Section 2.1 - Client Types](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1).
+Confidential client applications are apps that run on servers, such as web apps, web API apps, or service/daemon apps. Their internals are considered difficult to access, and therefore they can keep an application secret secure and out of sight of its users. Confidential clients can hold configuration-time secrets. The concept, just like public client applications, also is following the definitions included in [RFC6749 Section 2.1 - Client Types](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1).
 
 MSAL.NET enables the development of confidential client applications with the help of <xref:Microsoft.Identity.Client.ConfidentialClientApplicationBuilder> as well as included configuration and functions.
 

--- a/dotnet/api/overview/msal-public-client/index.md
+++ b/dotnet/api/overview/msal-public-client/index.md
@@ -1,15 +1,33 @@
 ---
-title: MSAL.NET Public Client
-description: "Public client applications are applications that run on devices, desktop computers, or in a web browser, that cannot be trusted to securely store secrets required for authentication."
+title: Core MSAL.NET Libraries
+description: "Core MSAL.NET libraries enable developers to build token acquisition flows into their applications both on the client (e.g., desktop, mobile, and web) as well as on the service sides (e.g., web APIs)."
 ---
 
-# MSAL.NET Public Client
+# Core MSAL.NET Libraries
 
-Public client applications are applications that run on devices, desktop computers, or in a web browser, that cannot be trusted to securely store secrets required for authentication. These applications can only access a web API or service on behalf of the authenticating user and cannot impersonate other users or groups. The reason they can't store a secret is mainly due to the fact that client applications can be reverse-engineered and secrets extracted. The concept is following the definitions included [RFC6749 Section 2.1 - Client Types](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1).
+Core MSAL.NET libraries enable developers to build token acquisition flows into their applications both on the client (e.g., desktop, mobile, and web) as well as on the service sides (e.g., web APIs).
 
-MSAL.NET enables the development of public client applications with the help of <xref:Microsoft.Identity.Client.PublicClientApplicationBuilder> as well as included configuration and functions. Refer to [Token acquisition](/entra/msal/dotnet/acquiring-tokens/overview) for more details.
+## Public client applications
+
+Public client applications are applications that run on devices, desktop computers, or in a web browser, that cannot be trusted to securely store secrets required for authentication. These applications can only access a web API or service on behalf of the authenticating user and cannot impersonate other users or groups. The reason they can't store a secret is mainly due to the fact that client applications can be reverse-engineered and secrets extracted. The concept is following the definitions included in [RFC6749 Section 2.1 - Client Types](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1).
+
+MSAL.NET enables the development of public client applications with the help of <xref:Microsoft.Identity.Client.PublicClientApplicationBuilder> as well as included configuration and functions.
+
+## Confidential client applications
+
+Confidential client applications are apps that run on servers, such as web apps, web API apps, or service/daemon apps. Their internals are considered difficult to access, and therefore they can keep an application secret secure and out of sight of its users. Confidential clients can hold configuration-time secrets. The concept, just like public client applicatrions, also is following the definitions included in [RFC6749 Section 2.1 - Client Types](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1).
+
+MSAL.NET enables the development of confidential client applications with the help of <xref:Microsoft.Identity.Client.ConfidentialClientApplicationBuilder> as well as included configuration and functions.
+
+## Get started
+
+Refer to [Token acquisition](/entra/msal/dotnet/acquiring-tokens/overview) for more details.
+
+- [PublicClientApplication](xref:Microsoft.Identity.Client.PublicClientApplication)
+- [ConfidentialClientApplication](xref:Microsoft.Identity.Client.ConfidentialClientApplication)
+- [ManagedIdentityApplication](xref:Microsoft.Identity.Client.ManagedIdentityApplication)
 
 ## Resources
 
-* [Public client and confidential client applications](/azure/active-directory/develop/msal-client-applications)
-* [RFC6749 - The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
+- [Public client and confidential client applications](/azure/active-directory/develop/msal-client-applications)
+- [RFC6749 - The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)

--- a/dotnet/docs-ref-toc/toc.yml
+++ b/dotnet/docs-ref-toc/toc.yml
@@ -3,7 +3,7 @@
   landingPageType: Root
   expanded: false
   items:
-  - name: Public Client
+  - name: Core MSAL.NET Libraries
     href: ~/api/overview/msal-public-client/index.md
     landingPageType: Service
     children:
@@ -22,7 +22,7 @@
     - Microsoft.Identity.Client.SSHCertificates
     - Microsoft.Identity.Client.TelemetryCore.TelemetryClient
     - Microsoft.Identity.Client.Utils.Windows
-  - name: Confidential Client
+  - name: Higher-Level Libraries
     landingPageType: Service
     children:
     - AspNetCore


### PR DESCRIPTION
This work also includes pointers to the right pages from the core MSAL.NET library page that was previously obstructed by the "moniker" for the .NET reference docs (if you choose one, e.g., for PCA, you can't see the other).