### PR TITLE
Make example work in Logging in MSAL.NET page

### DIFF
--- a/msal-dotnet-articles/advanced/exceptions/msal-logging.md
+++ b/msal-dotnet-articles/advanced/exceptions/msal-logging.md
@@ -118,7 +118,7 @@ Example:
         public void Log(LogEntry entry)
         {
             //Log Message here:
-            Console.WriteLine(entry.message);
+            Console.WriteLine(entry.Message);
         }
     }
 ```


### PR DESCRIPTION
There is an error in the [example on controlling the MSAL logging via an environment variable](https://learn.microsoft.com/en-us/entra/msal/dotnet/advanced/exceptions/msal-logging#log-level-from-an-environment-variable).
`LogEntry` does not have a property called `message` but rather `Message` (see [here](https://learn.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.abstractions.logentry?view=msal-web-dotnet-latest)).

This PR changes `entry.message` to `entry.Message` so the example can actually be compiled.