### PR TITLE
Update AcquireTokenOptions.xml - Fix Spelling of "authenticatiopn" to "authentication"

### DIFF
--- a/dotnet/xml/Microsoft.Identity.Abstractions/AcquireTokenOptions.xml
+++ b/dotnet/xml/Microsoft.Identity.Abstractions/AcquireTokenOptions.xml
@@ -85,7 +85,7 @@
       <Docs>
         <summary>
             Gets the name of the options describing the confidential client application (ClientID,
-            Region, Authority, client credentials). In ASP.NET Core, the authenticatiopn options name 
+            Region, Authority, client credentials). In ASP.NET Core, the authentication options name 
             is the same as the authentication scheme.
             </summary>
         <value>To be added.</value>


### PR DESCRIPTION
Corrected a simple typo.


As a somewhat related note though- 

> Gets the name of the options describing the confidential client application (ClientID, Region, Authority, client credentials). In ASP.NET Core, the authenticatiopn options name is the same as the authentication scheme.

The intended value which should be stored here, isn't crystal clear.

But- this PR, is only to correct the obvious typo.