### PR TITLE
Xamarin content curation (MSAL-Lib)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Security
 
-Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet) and [our GitHub organizations](https://opensource.microsoft.com/).
 
 If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/opensource/security/definition), please report it to us as described below.
 

--- a/msal-dotnet-articles/TOC.yml
+++ b/msal-dotnet-articles/TOC.yml
@@ -27,8 +27,6 @@
           href: acquiring-tokens/desktop-mobile/acquiring-tokens-interactively.md
         - name: Using MSAL.NET with Web Account Manager (WAM)
           href: acquiring-tokens/desktop-mobile/wam.md
-        - name: Xamarin
-          href: acquiring-tokens/desktop-mobile/mobile-applications.md
         - name: Sign-in users with social identities
           href: acquiring-tokens/desktop-mobile/social-identities.md
         - name: Integrated Windows Authentication for domain or Microsoft Entra joined machines

--- a/msal-dotnet-articles/acquiring-tokens/desktop-mobile/acquiring-tokens-interactively.md
+++ b/msal-dotnet-articles/acquiring-tokens/desktop-mobile/acquiring-tokens-interactively.md
@@ -190,13 +190,6 @@ AcquireTokenSilent(scopesForVendorApi, accounts.FirstOrDefault()).ExecuteAsync()
 
 For Microsoft personal accounts, re-prompting for consent on each native client call to authorize is the intended behavior. Native client identity is inherently insecure and the Microsoft identity platform chose to mitigate this for consumer services by prompting for consent each time the application is authorized.
 
-## Platform-specific details
-
-Depending on the platform, additional configuration might be required for interactive prompts:
-
-- [Configuration requirements and troubleshooting tips for Xamarin Android with MSAL.NET](/entra/identity-platform/msal-net-xamarin-android-considerations)
-- [Considerations for using Xamarin iOS with MSAL.NET](/entra/identity-platform/msal-net-xamarin-ios-considerations)
-
 ## Samples
 
 | Sample | Platform | Description |

--- a/msal-dotnet-articles/acquiring-tokens/desktop-mobile/mobile-applications.md
+++ b/msal-dotnet-articles/acquiring-tokens/desktop-mobile/mobile-applications.md
@@ -19,8 +19,6 @@ MSAL.NET can be used with authentication brokers on mobile devices, such as Micr
 To get started with MSAL.NET integration on Android, refer to the following resources:
 
 - [How to migrate Xamarin ADAL apps to MSAL for Android](/entra/identity-platform/msal-net-migration-android-broker)
-- [Xamarin Android Configuration Tips + Troubleshooting](/entra/identity-platform/msal-net-xamarin-android-considerations)
-- [Xamarin Android System Browser Info](/entra/identity-platform/msal-net-system-browser-android-considerations)
 
 To learn more about testing MSAL on Android devices, refer to the [MSAL for Android Wiki](https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki/Android-Emulator-with-MSAL).
 

--- a/msal-dotnet-articles/advanced/httpclient.md
+++ b/msal-dotnet-articles/advanced/httpclient.md
@@ -57,11 +57,6 @@ public class StaticClientWithProxyFactory : IMsalHttpClientFactory
 }
 ```
 
-
-## HttpClient and Xamarin iOS
-
-When using Xamarin iOS, it is recommended to create an `HttpClient` that explicitly uses the `NSURLSession`-based handler for iOS 7 and newer. MSAL.NET automatically creates an `HttpClient` that uses `NSURLSessionHandler` for iOS 7 and newer. For more information, read the [Xamarin iOS documentation for HttpClient](/xamarin/cross-platform/macios/http-stack).
-
 ## Troubleshooting
 
 **Problem**: On a desktop application, the authorization experience do not use the HttpClient I defined

--- a/msal-dotnet-articles/advanced/testing-apps-using-msal.md
+++ b/msal-dotnet-articles/advanced/testing-apps-using-msal.md
@@ -48,7 +48,7 @@ Daemon apps use pre-deployed secrets (passwords or certificates) to talk to Micr
 For native clients, there are several approaches to testing:
 
 - Use the [Username / Password](../acquiring-tokens/desktop-mobile/username-password-authentication.md) grant to fetch a token in a non-interactive way. This flow is not recommended in production, but it is reasonable to use it for testing.
-- Use a framework, like Appium or Xamarin.Test, that provides an automation interface for both your app and the MSAL created browser.
+- Use a framework, like Appium, that provides an automation interface for both your app and the MSAL created browser.
 - MSAL exposes an extensibility point that allows developers to inject their own browser experience. The MSAL team uses this internally to test interactive auth scenarios.
 
 ## Library feedback

--- a/msal-dotnet-articles/getting-started/initializing-client-applications.md
+++ b/msal-dotnet-articles/getting-started/initializing-client-applications.md
@@ -94,14 +94,6 @@ In the code snippets using application builders, many `.With` methods can be app
 
 The modifiers you can set on a public client or confidential client application builder can be found in the `AbstractApplicationBuilder<T>` class. The different methods can be found in the [Azure SDK for .NET documentation](/dotnet/api/microsoft.identity.client.abstractapplicationbuilder-1).
 
-### Modifiers specific to Xamarin.iOS applications
-
-The modifiers you can set on a public client application builder on Xamarin.iOS are:
-
-|Modifier | Description|
-|--------- | --------- |
-|`.WithIosKeychainSecurityGroup()` | **Xamarin.iOS only**: Sets the iOS key chain security group (for the cache persistence).|
-
 ### Modifiers specific to confidential client applications
 
 The modifiers specific to a confidential client application builder can be found in the `ConfidentialClientApplicationBuilder` class. The different methods can be found in the [Azure SDK for .NET documentation](/dotnet/api/microsoft.identity.client.confidentialclientapplicationbuilder). 

--- a/msal-dotnet-articles/getting-started/scenarios.md
+++ b/msal-dotnet-articles/getting-started/scenarios.md
@@ -54,7 +54,7 @@ To enable this interaction, MSAL.NET leverages a [web browser](/azure/active-dir
 
 #### Protecting the app itself with Intune
 
-Your mobile app (written in Xamarin.iOS or Xamarin.Android) can have app protection policies applied to it, so that it can be [managed by InTune](/mem/intune/developer/app-sdk) and recognized by Intune as a managed app. The [InTune SDK](/mem/intune/developer/app-sdk-get-started) is separate from MSAL, and it talks to Microsoft Entra ID on its own.
+Your mobile app can have app protection policies applied to it, so that it can be [managed by InTune](/mem/intune/developer/app-sdk) and recognized by Intune as a managed app. The [InTune SDK](/mem/intune/developer/app-sdk-get-started) is separate from MSAL, and it talks to Microsoft Entra ID on its own.
 
 ### Desktop or service daemon app that calls a web API as itself (in its own name)
 


### PR DESCRIPTION
This pull request includes several changes to the MSAL.NET documentation, primarily focusing on the removal of Xamarin-specific content and updates to security documentation. The most important changes are summarized below:

### Removal of Xamarin-specific content:

* [`msal-dotnet-articles/TOC.yml`](diffhunk://#diff-e56e0d486f461a1051243803f61a589d11ec0b7cf34bf0dfbcd09f848fbb13d2L30-L31): Removed the Xamarin section from the table of contents.
* [`msal-dotnet-articles/acquiring-tokens/desktop-mobile/acquiring-tokens-interactively.md`](diffhunk://#diff-1dfef849cf114e969860dc72ef983411ef7624d8c83c8b40155bd05ef1298d52L193-L199): Removed platform-specific details related to Xamarin.
* [`msal-dotnet-articles/acquiring-tokens/desktop-mobile/mobile-applications.md`](diffhunk://#diff-0e2b05c7a01d26e382aa566b9742cd5d75df14f6ab7a1a68c088be7b36fdc992L22-L23): Removed Xamarin Android configuration tips and system browser information.
* [`msal-dotnet-articles/advanced/httpclient.md`](diffhunk://#diff-84c9bb5596568ce9acaa8360da7110f14c9f01bd949225bf089affda1eceabaeL60-L64): Removed recommendations for using `HttpClient` with Xamarin iOS.
* [`msal-dotnet-articles/getting-started/initializing-client-applications.md`](diffhunk://#diff-6fee52341e2b6524667a17ab2a2602f0a44d918f92810ca2cb893b27037478beL97-L104): Removed modifiers specific to Xamarin.iOS applications.

### Security documentation update:

* [`SECURITY.md`](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L5-R5): Simplified the list of GitHub organizations by removing redundant entries.