### PR TITLE
Add MacOS Broker page to TOC & edit WAM title for clarity

### DIFF
--- a/msal-dotnet-articles/TOC.yml
+++ b/msal-dotnet-articles/TOC.yml
@@ -25,8 +25,10 @@
         items:
         - name: Acquiring tokens interactively
           href: acquiring-tokens/desktop-mobile/acquiring-tokens-interactively.md
-        - name: Using MSAL.NET with Web Account Manager (WAM)
+        - name: Using MSAL.NET with broker on Windows (Web Account Manager / WAM)
           href: ./acquiring-tokens/desktop-mobile/wam.md
+        - name: Using MSAL.NET with broker on MacOS
+          href: ./acquiring-tokens/desktop-mobile/macos-broker-dotnet-sdk.md
         - name: Using MSAL.Net with broker on Linux distributions
           href: ./acquiring-tokens/desktop-mobile/linux-dotnet-sdk.md
         - name: Using MSAL.Net with WSL


### PR DESCRIPTION
The `macos-broker-dotnet-sdk.md` page was added in Jan, but was never linked into the TOC, making it hard to find unless someone sends a direct link. This PR adds the MacOS Broker + MSAL.NET page to the TOC as well as editing the title of the Windows broker (WAM) page to match Mac/Linux for clarity